### PR TITLE
[fix] Added fallback to browsertabs before falling back to the InAppB…

### DIFF
--- a/src/agent/browsertab.js
+++ b/src/agent/browsertab.js
@@ -1,0 +1,27 @@
+function BrowserTab() {
+    this.open = this.open.bind(this);
+    this.close = this.close.bind(this);
+}
+
+BrowserTab.isAvailable = function (callback) {
+    callback(window.cordova.plugins.browsertab != undefined);
+};
+
+BrowserTab.prototype.open = function (url, handler) {
+    var browser = window.cordova.plugins.browsertab;
+    var tab = browser.openUrl(
+        url,
+        function (successResp) {
+            handler(null, { event: 'loaded' });
+        },
+        function (failureResp) {
+            handler(e, null);
+        }
+    );
+};
+
+BrowserTab.prototype.close = function () {
+    window.cordova.plugins.browsertab.close();
+};
+
+module.exports = BrowserTab;

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -1,12 +1,17 @@
 var BrowserAgent = require('./browser');
 var WebViewAgent = require('./webview');
+var BrowserTab = require('./browsertab');
 
 module.exports = function getAgent(callback) {
-  return BrowserAgent.isAvailable(function (available) {
-    if (available) {
-      return callback(null, new BrowserAgent());
-    }
-    return callback(null, new WebViewAgent());
-  });
+    return BrowserAgent.isAvailable(function (available) {
+        if (available) {
+            return callback(null, new BrowserAgent());
+        }
+        return BrowserTab.isAvailable(function (available) {
+            if (available) {
+                return callback(null, new BrowserTab());
+            }
+            return callback(null, new WebViewAgent());
+        })
+    });
 };
-


### PR DESCRIPTION
Added a fallback to the [cordova-plugin-browsertab](https://github.com/google/cordova-plugin-browsertab/tree/master/plugin). This fallback is used when the `SafariWebViewController` is not available. This requires the plugin to be installed. For Ionic 2 developers like myself, you can find more info [here](https://ionicframework.com/docs/native/browser-tab/). When the `BrowserTab` is not available it falls back to the `InAppBrowser` as usual.

Logging in using the `InAppBrowser` doesn't work though as I get the `ERR_UNKNOWN_URL_SCHEME ` error after entering credentials en logging in.